### PR TITLE
Fix manual scene image path persistence

### DIFF
--- a/app/electron/ipc-handlers.js
+++ b/app/electron/ipc-handlers.js
@@ -176,7 +176,7 @@ function registerIpcHandlers(ipcMain, getMainWindow, storagePath, systemInfo = {
     try {
       const scene = projectRepo.getScene(sceneId);
       const result = await imageGen.generate(scene);
-      projectRepo.updateScene(sceneId, { imageUrl: result.filePath, imageStatus: 'generated' });
+      projectRepo.updateScene(sceneId, { imagePath: result.filePath, imageStatus: 'generated' });
       return { success: true, data: result };
     } catch (err) {
       logger.error('scene:generateImage failed', err);


### PR DESCRIPTION
### Motivation
- The manual `scene:generateImage` IPC handler saved generated images under `imageUrl` while the rest of the codebase (workflow engine, scene preview UI, and video renderer) expects `imagePath`, so manually generated images were not displayed or reused correctly.

### Description
- Change the `scene:generateImage` handler in `app/electron/ipc-handlers.js` to persist `imagePath` (the actual `result.filePath`) and update `imageStatus` to `generated` for consistency with existing consumers.

### Testing
- Built the renderer with `npm run build:renderer` which compiled successfully, and verified field usage with `rg -n "imageUrl|imagePath" app` to confirm consistent references across modules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba827f955483248a41cf59a2cf1b58)