### PR TITLE
Fix workflow start error handling and scene image field

### DIFF
--- a/app/electron/ipc-handlers.js
+++ b/app/electron/ipc-handlers.js
@@ -176,7 +176,7 @@ function registerIpcHandlers(ipcMain, getMainWindow, storagePath, systemInfo = {
     try {
       const scene = projectRepo.getScene(sceneId);
       const result = await imageGen.generate(scene);
-      projectRepo.updateScene(sceneId, { imageUrl: result.filePath, imageStatus: 'generated' });
+      projectRepo.updateScene(sceneId, { imagePath: result.filePath, imageStatus: 'generated' });
       return { success: true, data: result };
     } catch (err) {
       logger.error('scene:generateImage failed', err);
@@ -302,7 +302,7 @@ function registerIpcHandlers(ipcMain, getMainWindow, storagePath, systemInfo = {
       if (existing && existing.status === 'running') {
         return { success: false, error: 'このプロジェクトのワークフローは既に実行中です' };
       }
-      workflowEngine.startWorkflow(projectId);
+      await workflowEngine.startWorkflow(projectId);
       return { success: true };
     } catch (err) {
       logger.error('workflow:start failed', err);


### PR DESCRIPTION
### Motivation
- Prevent the `workflow:start` IPC handler from returning a false `success: true` when `startWorkflow` fails, and ensure generated scene images are stored using the canonical `imagePath` field for consistency.

### Description
- Change `scene:generateImage` to update scenes with `imagePath` instead of `imageUrl` to match repository/scene mapping and renderer expectations.
- `await` the call to `workflowEngine.startWorkflow(projectId)` in the `workflow:start` IPC handler so startup errors propagate to the caller.

### Testing
- Ran `node --check app/electron/ipc-handlers.js` which succeeded. 
- Built the renderer with `npm run build:renderer` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba8270a1c88324b1c50dd38b187380)