### PR TITLE
docs: Add quick start section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Enter a topic and automatically generate a full video — from AI script writing
 | 📤 YouTube Upload | YouTube Data API で自動投稿 |
 | 🔄 Workflow Engine | 全工程をパイプラインで一括実行 |
 
+## Quick Start
+
+```bash
+git clone https://github.com/toukanno/video-auto-editor-2.git
+cd video-auto-editor-2
+npm install
+npm start
+```
+
 ## Architecture / アーキテクチャ
 
 ```


### PR DESCRIPTION
## Summary

- Add a "Quick Start" section to README.md after the Features table
- Provides a minimal 4-step onboarding path (clone, install, start) for new users

## Test plan

- [ ] Verify the Quick Start section renders correctly on GitHub
- [ ] Confirm the commands in the section work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)