### PR TITLE
feat: Add vitest test suite (17 tests)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev:renderer": "webpack serve --config webpack.renderer.config.js --mode development",
     "build:renderer": "webpack --config webpack.renderer.config.js --mode production",
     "build": "npm run build:renderer && electron-builder",
-    "pack": "electron-builder --dir"
+    "pack": "electron-builder --dir",
+    "test": "vitest run"
   },
   "build": {
     "appId": "com.aivideo.generator",
@@ -60,6 +61,7 @@
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "style-loader": "^4.0.0",
+    "vitest": "^4.1.0",
     "wait-on": "^8.0.0",
     "webpack": "^5.95.0",
     "webpack-cli": "^5.1.0",

--- a/tests/scene-planner.test.js
+++ b/tests/scene-planner.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+// ScenePlanner requires aiProvider in constructor but _parseDuration and splitScenes
+// don't use it, so we pass null for pure function testing
+const { ScenePlanner } = require('../app/modules/scene-planner/index.js');
+
+describe('ScenePlanner', () => {
+  const planner = new ScenePlanner(null);
+
+  describe('_parseDuration', () => {
+    it('returns default 10 for null', () => {
+      expect(planner._parseDuration(null)).toBe(10);
+    });
+
+    it('returns default 10 for undefined', () => {
+      expect(planner._parseDuration(undefined)).toBe(10);
+    });
+
+    it('passes through numbers', () => {
+      expect(planner._parseDuration(5)).toBe(5);
+    });
+
+    it('parses string with digits', () => {
+      expect(planner._parseDuration('30s')).toBe(30);
+    });
+
+    it('parses plain number string', () => {
+      expect(planner._parseDuration('15')).toBe(15);
+    });
+
+    it('returns default for non-numeric string', () => {
+      expect(planner._parseDuration('abc')).toBe(10);
+    });
+  });
+
+  describe('splitScenes', () => {
+    it('returns empty array for null input', () => {
+      expect(planner.splitScenes(null)).toEqual([]);
+    });
+
+    it('returns empty array for missing scenes', () => {
+      expect(planner.splitScenes({})).toEqual([]);
+    });
+
+    it('splits scenes with correct fields', () => {
+      const result = planner.splitScenes({
+        scenes: [
+          { title: 'Intro', narration: 'Hello', duration: 5, imagePrompt: 'sunset' },
+          { title: 'End', narration: 'Bye', duration: 10 },
+        ]
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].title).toBe('Intro');
+      expect(result[0].narration).toBe('Hello');
+      expect(result[0].duration).toBe(5);
+      expect(result[0].imagePrompt).toBe('sunset');
+      expect(result[0].imageStatus).toBe('pending');
+      expect(result[0].status).toBe('draft');
+      expect(result[0].id).toBeTruthy(); // UUID generated
+
+      expect(result[1].sceneNumber).toBe(2);
+      expect(result[1].imagePrompt).toBe('');
+    });
+
+    it('provides default values for missing fields', () => {
+      const result = planner.splitScenes({ scenes: [{}] });
+      expect(result[0].title).toBe('Scene 1');
+      expect(result[0].narration).toBe('');
+      expect(result[0].duration).toBe(10); // default
+      expect(result[0].sceneNumber).toBe(1);
+    });
+  });
+});

--- a/tests/subtitle-generator.test.js
+++ b/tests/subtitle-generator.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+// Import the module directly — _formatTime and _formatTimeVTT are instance methods
+const { SubtitleGenerator } = require('../app/modules/subtitle-generator/index.js');
+
+describe('SubtitleGenerator', () => {
+  const gen = new SubtitleGenerator();
+
+  describe('_formatTime (SRT format)', () => {
+    it('formats zero seconds', () => {
+      expect(gen._formatTime(0)).toBe('00:00:00,000');
+    });
+
+    it('formats fractional seconds', () => {
+      expect(gen._formatTime(1.5)).toBe('00:00:01,500');
+    });
+
+    it('formats minutes', () => {
+      expect(gen._formatTime(65)).toBe('00:01:05,000');
+    });
+
+    it('formats hours', () => {
+      expect(gen._formatTime(3661.5)).toBe('01:01:01,500');
+    });
+
+    it('handles large values', () => {
+      expect(gen._formatTime(36000)).toBe('10:00:00,000');
+    });
+  });
+
+  describe('_formatTimeVTT (VTT format)', () => {
+    it('uses dot instead of comma', () => {
+      expect(gen._formatTimeVTT(1.5)).toBe('00:00:01.500');
+    });
+
+    it('formats zero', () => {
+      expect(gen._formatTimeVTT(0)).toBe('00:00:00.000');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- vitest導入、テストスクリプト追加
- SubtitleGenerator テスト7件（SRT/VTT時刻フォーマット）
- ScenePlanner テスト10件（duration解析、シーン分割）
- Electron不要の純粋関数のみ対象

## Test plan
- [x] `npx vitest run` 全17件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)